### PR TITLE
Remove IfModule check

### DIFF
--- a/5.16/contrib/etc/httpd.d/50-mpm.conf.template
+++ b/5.16/contrib/etc/httpd.d/50-mpm.conf.template
@@ -1,13 +1,11 @@
-<IfModule mpm_prefork_module>
-    # This value should mirror what is set in MinSpareServers.
-    StartServers            ${HTTPD_START_SERVERS}
-    MinSpareServers         ${HTTPD_START_SERVERS}
-    MaxSpareServers         ${HTTPD_MAX_SPARE_SERVERS}
-    # The MaxRequestWorkers directive sets the limit on the number of
-    # simultaneous requests that will be served.
-    # The default value, when no cgroup limits are set is 256.
-    MaxRequestWorkers       ${HTTPD_MAX_REQUEST_WORKERS}
-    ServerLimit             ${HTTPD_MAX_REQUEST_WORKERS}
-    MaxConnectionsPerChild  4000
-    MaxKeepAliveRequests    100
-</IfModule>
+# This value should mirror what is set in MinSpareServers.
+StartServers            ${HTTPD_START_SERVERS}
+MinSpareServers         ${HTTPD_START_SERVERS}
+MaxSpareServers         ${HTTPD_MAX_SPARE_SERVERS}
+# The MaxRequestWorkers directive sets the limit on the number of
+# simultaneous requests that will be served.
+# The default value, when no cgroup limits are set is 256.
+MaxRequestWorkers       ${HTTPD_MAX_REQUEST_WORKERS}
+ServerLimit             ${HTTPD_MAX_REQUEST_WORKERS}
+MaxConnectionsPerChild  4000
+MaxKeepAliveRequests    100

--- a/5.20/contrib/etc/httpd.d/50-mpm.conf.template
+++ b/5.20/contrib/etc/httpd.d/50-mpm.conf.template
@@ -1,13 +1,11 @@
-<IfModule mpm_prefork_module>
-    # This value should mirror what is set in MinSpareServers.
-    StartServers            ${HTTPD_START_SERVERS}
-    MinSpareServers         ${HTTPD_START_SERVERS}
-    MaxSpareServers         ${HTTPD_MAX_SPARE_SERVERS}
-    # The MaxRequestWorkers directive sets the limit on the number of
-    # simultaneous requests that will be served.
-    # The default value, when no cgroup limits are set is 256.
-    MaxRequestWorkers       ${HTTPD_MAX_REQUEST_WORKERS}
-    ServerLimit             ${HTTPD_MAX_REQUEST_WORKERS}
-    MaxConnectionsPerChild  4000
-    MaxKeepAliveRequests    100
-</IfModule>
+# This value should mirror what is set in MinSpareServers.
+StartServers            ${HTTPD_START_SERVERS}
+MinSpareServers         ${HTTPD_START_SERVERS}
+MaxSpareServers         ${HTTPD_MAX_SPARE_SERVERS}
+# The MaxRequestWorkers directive sets the limit on the number of
+# simultaneous requests that will be served.
+# The default value, when no cgroup limits are set is 256.
+MaxRequestWorkers       ${HTTPD_MAX_REQUEST_WORKERS}
+ServerLimit             ${HTTPD_MAX_REQUEST_WORKERS}
+MaxConnectionsPerChild  4000
+MaxKeepAliveRequests    100


### PR DESCRIPTION
Since we're processing our custom configuration before reading system
config files, the MPM prefork module is not loaded at the time of the
evaluation. Since this image will always run with Prefork (threaded
workers don't work with Perl), we can always set the settings, not
needing to check for the module to be loaded.

Fixes RHBZ https://bugzilla.redhat.com/show_bug.cgi?id=1339514

@bparees PTAL